### PR TITLE
Use packaging module to extract and compare torchvision version

### DIFF
--- a/models/transposenet/pencoder.py
+++ b/models/transposenet/pencoder.py
@@ -22,7 +22,8 @@ from torch import Tensor
 
 # needed due to empty tensor bug in pytorch and torchvision 0.5
 import torchvision
-if float(torchvision.__version__[:3]) < 0.7:
+from packaging import version
+if version.parse(torchvision.__version__) < version.parse("0.7"):
     from torchvision.ops import _new_empty_tensor
     from torchvision.ops.misc import _output_size
 


### PR DESCRIPTION
First of all, thank you for sharing the implementation of your paper. I am not sure if this repository is opened to pull requests but I encountered a minor issue when trying to run this code using a more recent version of `torchvision` (e.g. 0.14.1) so I decided to share a fix in this PR. Here is the stack trace of the error: 

```
Traceback (most recent call last):
  File "main.py", line 14, in <module>
    from models.pose_regressors import get_model
  File "/ws/transposenet/models/pose_regressors.py", line 2, in <module>
    from .transposenet.TransPoseNet import TransPoseNet
  File "/ws/transposenet/models/transposenet/TransPoseNet.py", line 9, in <module>
    from .pencoder import NestedTensor, nested_tensor_from_tensor_list
  File "/ws/transposenet/models/transposenet/pencoder.py", line 28, in <module>
    from torchvision.ops import _new_empty_tensor
ImportError: cannot import name '_new_empty_tensor' from 'torchvision.ops' (/usr/local/lib/python3.8/dist-packages/torchvision/ops/__init__.py)
```

I noticed there is no license information in this repository. Do you plan on adding it later? If so, under what kind of license will this code be distributed?